### PR TITLE
Reorder tenancy middleware for web group

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -25,8 +25,8 @@ class Kernel extends HttpKernel
     protected $middlewareGroups = [
         'web' => [
             // Tenancy middleware
-            \Stancl\Tenancy\Middleware\InitializeTenancyBySubdomain::class,
             \Stancl\Tenancy\Middleware\PreventAccessFromCentralDomains::class,
+            \Stancl\Tenancy\Middleware\InitializeTenancyBySubdomain::class,
 
             // Standard Laravel middleware
             \App\Http\Middleware\EncryptCookies::class,


### PR DESCRIPTION
## Summary
- ensure PreventAccessFromCentralDomains runs before InitializeTenancyBySubdomain in web middleware stack

## Testing
- `KEY=$(php -r "echo base64_encode(random_bytes(32));"); APP_KEY=base64:$KEY vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6891b8321f94832ea8c0767269467e97