### PR TITLE
Add central domain access prevention middleware

### DIFF
--- a/config/tenancy.php
+++ b/config/tenancy.php
@@ -13,10 +13,11 @@ return [
      
 
     'identification' => [
-    'middleware' => [
-        \Stancl\Tenancy\Middleware\InitializeTenancyBySubdomain::class,
+        'middleware' => [
+            \Stancl\Tenancy\Middleware\InitializeTenancyBySubdomain::class,
+            \Stancl\Tenancy\Middleware\PreventAccessFromCentralDomains::class,
+        ],
     ],
-],
     /**
      * The list of domains hosting your central app.
      *


### PR DESCRIPTION
## Summary
- prevent central domain access by adding Tenancy middleware

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6891b82f8b64832e98901baf835507c5