### PR TITLE
Use domain-based tenant identification

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -26,7 +26,7 @@ class Kernel extends HttpKernel
         'web' => [
             // Tenancy middleware
             \Stancl\Tenancy\Middleware\PreventAccessFromCentralDomains::class,
-            \Stancl\Tenancy\Middleware\InitializeTenancyBySubdomain::class,
+            \Stancl\Tenancy\Middleware\InitializeTenancyByDomain::class,
 
             // Standard Laravel middleware
             \App\Http\Middleware\EncryptCookies::class,

--- a/config/tenancy.php
+++ b/config/tenancy.php
@@ -11,7 +11,7 @@ return [
 
     'identification' => [
         'middleware' => [
-            \Stancl\Tenancy\Middleware\InitializeTenancyBySubdomain::class,
+            \Stancl\Tenancy\Middleware\InitializeTenancyByDomain::class,
             \Stancl\Tenancy\Middleware\PreventAccessFromCentralDomains::class,
         ],
     ],


### PR DESCRIPTION
## Summary
- initialize tenancy using full domain instead of subdomain
- adjust web middleware group to match domain-based identification

## Testing
- `php artisan config:clear`
- `php artisan migrate`
- `php artisan db:seed`
- `php artisan test`
- `curl -H "Host: client1.localhost" -v http://127.0.0.1:8000` *(returns 'Tenant not found')*


------
https://chatgpt.com/codex/tasks/task_e_6891e5278bac832e97c7690f5e00f535